### PR TITLE
Add drag-and-drop demo with preset error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# motion-test
+# Drag & Drop Presets Demo
+
+This repository hosts a minimal, framework-free demo that showcases drag and drop
+interactions alongside simple preset styling. The project also includes
+lightweight error handling so that common issues surface in the browser console.
+
+## Getting started
+
+1. Open `index.html` in your browser.
+2. Drag any of the colored notes into the canvas area.
+3. Apply a preset to restyle the canvas.
+
+If an issue occurs while dragging, dropping, or applying a preset, a concise
+error message will appear in the browser console to help with debugging.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Drag & Drop Presets Demo</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="app">
+      <section class="panel">
+        <h1>Drag & Drop Presets</h1>
+        <p>
+          Drag the cards into the canvas and try different presets. Open the
+          browser console to view helpful error messages if something goes wrong.
+        </p>
+        <div class="draggables" aria-label="Draggable cards">
+          <button class="draggable" draggable="true" data-color="#ffb703">
+            Note A
+          </button>
+          <button class="draggable" draggable="true" data-color="#219ebc">
+            Note B
+          </button>
+          <button class="draggable" draggable="true" data-color="#8ecae6">
+            Note C
+          </button>
+        </div>
+        <div class="presets" aria-label="Preset buttons">
+          <h2>Presets</h2>
+          <button class="preset" data-preset="sunset">Sunset</button>
+          <button class="preset" data-preset="forest">Forest</button>
+          <button class="preset" data-preset="ocean">Ocean</button>
+        </div>
+      </section>
+      <section class="canvas" id="drop-zone" aria-label="Drop zone" tabindex="0">
+        <p class="placeholder">Drop cards here</p>
+      </section>
+    </main>
+    <script src="src/app.js" type="module"></script>
+  </body>
+</html>

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,123 @@
+const presets = {
+  sunset: {
+    background: 'linear-gradient(135deg, #ff9a8b 0%, #fecfef 100%)',
+    borderColor: '#f3722c',
+  },
+  forest: {
+    background: 'linear-gradient(135deg, #1b4332 0%, #95d5b2 100%)',
+    borderColor: '#2d6a4f',
+  },
+  ocean: {
+    background: 'linear-gradient(135deg, #012a4a 0%, #61a5c2 100%)',
+    borderColor: '#014f86',
+  },
+};
+
+const dropZone = document.getElementById('drop-zone');
+const draggableItems = Array.from(document.querySelectorAll('.draggable'));
+const presetButtons = Array.from(document.querySelectorAll('.preset'));
+
+const logError = (context, error) => {
+  console.error(`Something went wrong while ${context}.`, error);
+};
+
+const safeListener = (context, handler) => {
+  return (event) => {
+    try {
+      handler(event);
+    } catch (error) {
+      logError(context, error);
+    }
+  };
+};
+
+const handleDragStart = safeListener('starting a drag', (event) => {
+  event.dataTransfer.setData('text/plain', event.target.dataset.color);
+  event.dataTransfer.effectAllowed = 'move';
+  event.target.classList.add('dragging');
+});
+
+const handleDragEnd = safeListener('finishing a drag', (event) => {
+  event.target.classList.remove('dragging');
+});
+
+const handleDragOver = safeListener('dragging over the canvas', (event) => {
+  event.preventDefault();
+  event.dataTransfer.dropEffect = 'move';
+  dropZone.classList.add('is-target');
+});
+
+const handleDragLeave = safeListener('leaving the canvas', () => {
+  dropZone.classList.remove('is-target');
+});
+
+const createCard = safeListener('creating a card', (event) => {
+  const color = event.dataTransfer.getData('text/plain');
+  if (!color) {
+    throw new Error('The dragged item did not provide a color.');
+  }
+
+  const card = document.createElement('div');
+  card.className = 'card';
+  card.style.backgroundColor = color;
+  card.textContent = `Card ${dropZone.querySelectorAll('.card').length + 1}`;
+  dropZone.appendChild(card);
+  dropZone.classList.remove('is-target');
+  togglePlaceholder();
+});
+
+const applyPreset = safeListener('applying the preset', (event) => {
+  const presetName = event.target.dataset.preset;
+  const preset = presets[presetName];
+
+  if (!preset) {
+    throw new Error(`Preset "${presetName}" does not exist.`);
+  }
+
+  dropZone.style.background = preset.background;
+  dropZone.style.borderColor = preset.borderColor;
+});
+
+const togglePlaceholder = () => {
+  const placeholder = dropZone.querySelector('.placeholder');
+  const hasCards = dropZone.querySelectorAll('.card').length > 0;
+
+  if (hasCards && placeholder) {
+    placeholder.remove();
+  } else if (!hasCards && !placeholder) {
+    const newPlaceholder = document.createElement('p');
+    newPlaceholder.className = 'placeholder';
+    newPlaceholder.textContent = 'Drop cards here';
+    dropZone.appendChild(newPlaceholder);
+  }
+};
+
+dropZone.addEventListener('dragover', handleDragOver);
+dropZone.addEventListener('dragleave', handleDragLeave);
+dropZone.addEventListener('drop', (event) => {
+  event.preventDefault();
+  createCard(event);
+});
+
+draggableItems.forEach((item) => {
+  item.addEventListener('dragstart', handleDragStart);
+  item.addEventListener('dragend', handleDragEnd);
+});
+
+presetButtons.forEach((button) => {
+  button.addEventListener('click', applyPreset);
+});
+
+window.addEventListener(
+  'error',
+  safeListener('handling an unexpected window error', (event) => {
+    logError('handling an unexpected window error', event.error);
+  })
+);
+
+window.addEventListener(
+  'unhandledrejection',
+  safeListener('handling an unhandled promise rejection', (event) => {
+    logError('handling an unhandled promise rejection', event.reason);
+  })
+);

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,147 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #f5f5f5, #cbd5f5 80%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+main.app {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 2rem;
+  padding: 2rem;
+  max-width: 960px;
+  width: 100%;
+}
+
+.panel {
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(10px);
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.12);
+}
+
+.panel h1 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  font-size: 1.75rem;
+}
+
+.panel p {
+  margin-top: 0;
+  color: #475569;
+  line-height: 1.5;
+}
+
+.draggables {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.draggable {
+  padding: 0.75rem 1rem;
+  border: none;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: grab;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+  color: #0f172a;
+}
+
+.draggable:focus-visible {
+  outline: 2px solid #1d4ed8;
+  outline-offset: 2px;
+}
+
+.draggable.dragging {
+  opacity: 0.6;
+  transform: scale(0.95);
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.2);
+}
+
+.presets {
+  margin-top: 2rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.preset {
+  padding: 0.65rem 0.75rem;
+  border: 2px solid transparent;
+  border-radius: 12px;
+  background: #1d4ed8;
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.preset:focus-visible {
+  outline: 2px solid #0ea5e9;
+  outline-offset: 2px;
+}
+
+.preset:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 20px rgba(37, 99, 235, 0.2);
+}
+
+.canvas {
+  background: rgba(255, 255, 255, 0.95);
+  border: 4px dashed #94a3b8;
+  border-radius: 24px;
+  min-height: 360px;
+  padding: 1rem;
+  display: grid;
+  gap: 1rem;
+  align-content: start;
+  position: relative;
+  transition: border-color 150ms ease, background 150ms ease;
+}
+
+.canvas.is-target {
+  border-color: #2563eb;
+}
+
+.placeholder {
+  margin: auto;
+  color: #94a3b8;
+  font-size: 1.1rem;
+}
+
+.card {
+  padding: 1rem;
+  border-radius: 16px;
+  color: #1f2937;
+  font-weight: 600;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.15);
+}
+
+@media (max-width: 900px) {
+  main.app {
+    grid-template-columns: 1fr;
+  }
+
+  .panel {
+    order: 2;
+  }
+
+  .canvas {
+    order: 1;
+  }
+}


### PR DESCRIPTION
## Summary
- add a static demo page that showcases draggable notes, a drop zone, and preset styling controls
- implement shared error-handling helpers so drag, drop, and preset interactions log meaningful messages
- style the interface with a responsive layout and update the README with usage instructions

## Testing
- not run (static files only)


------
https://chatgpt.com/codex/tasks/task_e_68ccbdfc80148324b83c5f9a8fee4924