### PR TITLE
Add draggable shapes canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# motion-test
+# Motion Test
+
+Simple drag-and-drop playground that lets you place rectangles and circles from the toolbar onto the canvas and reposition them freely. Open `index.html` in a browser to try it out.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Shape Canvas</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="workspace">
+      <aside class="toolbar" aria-label="Shape toolbar">
+        <h1 class="toolbar__title">Shapes</h1>
+        <div class="shape-template shape-template--rectangle" draggable="true" data-shape="rectangle" role="button" tabindex="0" aria-label="Drag to add rectangle"></div>
+        <div class="shape-template shape-template--circle" draggable="true" data-shape="circle" role="button" tabindex="0" aria-label="Drag to add circle"></div>
+        <p class="toolbar__hint">Drag a shape onto the canvas, then drag again to reposition.</p>
+      </aside>
+      <section class="canvas-container">
+        <h2 class="canvas__title">Canvas</h2>
+        <div id="canvas" class="canvas" role="application" aria-label="Shape canvas" tabindex="0"></div>
+      </section>
+    </main>
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,112 @@
+const toolbar = document.querySelector('.toolbar');
+const canvas = document.getElementById('canvas');
+const shapeDataType = 'application/x-shape-type';
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function enableCanvasShapeDragging(shape) {
+  shape.addEventListener('pointerdown', (event) => {
+    if (event.button !== 0) {
+      return;
+    }
+
+    event.preventDefault();
+    const canvasRect = canvas.getBoundingClientRect();
+    const shapeRect = shape.getBoundingClientRect();
+    const offsetX = event.clientX - shapeRect.left;
+    const offsetY = event.clientY - shapeRect.top;
+
+    shape.setPointerCapture(event.pointerId);
+
+    const handlePointerMove = (moveEvent) => {
+      const currentCanvasRect = canvas.getBoundingClientRect();
+      const targetX = moveEvent.clientX - currentCanvasRect.left - offsetX;
+      const targetY = moveEvent.clientY - currentCanvasRect.top - offsetY;
+      const maxX = currentCanvasRect.width - shape.offsetWidth;
+      const maxY = currentCanvasRect.height - shape.offsetHeight;
+
+      shape.style.left = `${clamp(targetX, 0, maxX)}px`;
+      shape.style.top = `${clamp(targetY, 0, maxY)}px`;
+    };
+
+    const handlePointerUp = (upEvent) => {
+      shape.releasePointerCapture(upEvent.pointerId);
+      shape.removeEventListener('pointermove', handlePointerMove);
+      shape.removeEventListener('pointerup', handlePointerUp);
+      shape.removeEventListener('pointercancel', handlePointerUp);
+    };
+
+    shape.addEventListener('pointermove', handlePointerMove);
+    shape.addEventListener('pointerup', handlePointerUp);
+    shape.addEventListener('pointercancel', handlePointerUp);
+  });
+}
+
+function createShape(type, x, y) {
+  const shape = document.createElement('div');
+  shape.classList.add('canvas-shape', type);
+  shape.setAttribute('role', 'img');
+  shape.setAttribute('aria-label', `${type} shape`);
+  shape.style.left = '0px';
+  shape.style.top = '0px';
+  shape.draggable = false;
+
+  canvas.appendChild(shape);
+
+  const shapeRect = shape.getBoundingClientRect();
+  const canvasRect = canvas.getBoundingClientRect();
+  const centeredLeft = x - shapeRect.width / 2;
+  const centeredTop = y - shapeRect.height / 2;
+
+  const maxX = canvasRect.width - shapeRect.width;
+  const maxY = canvasRect.height - shapeRect.height;
+
+  shape.style.left = `${clamp(centeredLeft, 0, maxX)}px`;
+  shape.style.top = `${clamp(centeredTop, 0, maxY)}px`;
+
+  enableCanvasShapeDragging(shape);
+  return shape;
+}
+
+function handleToolbarKeydown(event) {
+  const target = event.target.closest('.shape-template');
+  if (!target) {
+    return;
+  }
+
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault();
+    const canvasRect = canvas.getBoundingClientRect();
+    createShape(target.dataset.shape, canvasRect.width / 2, canvasRect.height / 2);
+  }
+}
+
+toolbar.addEventListener('keydown', handleToolbarKeydown);
+
+Array.from(toolbar.querySelectorAll('.shape-template')).forEach((template) => {
+  template.addEventListener('dragstart', (event) => {
+    event.dataTransfer.effectAllowed = 'copy';
+    event.dataTransfer.setData(shapeDataType, template.dataset.shape);
+  });
+});
+
+canvas.addEventListener('dragover', (event) => {
+  event.preventDefault();
+  event.dataTransfer.dropEffect = 'copy';
+});
+
+canvas.addEventListener('drop', (event) => {
+  event.preventDefault();
+  const type = event.dataTransfer.getData(shapeDataType);
+  if (!type) {
+    return;
+  }
+
+  const canvasRect = canvas.getBoundingClientRect();
+  const x = event.clientX - canvasRect.left;
+  const y = event.clientY - canvasRect.top;
+
+  createShape(type, x, y);
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,112 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background-color: #f4f4f4;
+  color: #1d1d1d;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.workspace {
+  display: flex;
+  min-height: 100vh;
+}
+
+.toolbar {
+  flex: 0 0 220px;
+  padding: 1.5rem;
+  background: #2f3542;
+  color: #ffffff;
+  box-shadow: inset -1px 0 0 rgba(0, 0, 0, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.toolbar__title {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.toolbar__hint {
+  margin-top: auto;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.shape-template {
+  width: 120px;
+  height: 80px;
+  border-radius: 0.5rem;
+  background: rgba(255, 255, 255, 0.85);
+  border: 2px dashed rgba(0, 0, 0, 0.2);
+  cursor: grab;
+  align-self: flex-start;
+}
+
+.shape-template:focus {
+  outline: 3px solid #70a1ff;
+}
+
+.shape-template:active {
+  cursor: grabbing;
+}
+
+.shape-template--circle {
+  border-radius: 50%;
+  width: 90px;
+  height: 90px;
+}
+
+.canvas-container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 1.5rem;
+  background: #f4f6fb;
+}
+
+.canvas__title {
+  margin: 0 0 1rem 0;
+  font-size: 1.4rem;
+  color: #2f3542;
+}
+
+.canvas {
+  flex: 1;
+  position: relative;
+  background: #ffffff;
+  border: 2px dashed #ced6e0;
+  border-radius: 1rem;
+  overflow: hidden;
+}
+
+.canvas-shape {
+  position: absolute;
+  cursor: grab;
+  transition: box-shadow 0.2s ease;
+  border: 2px solid rgba(47, 53, 66, 0.4);
+  background: rgba(112, 161, 255, 0.4);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
+  touch-action: none;
+}
+
+.canvas-shape:active {
+  cursor: grabbing;
+  box-shadow: 0 12px 20px rgba(0, 0, 0, 0.2);
+}
+
+.canvas-shape.rectangle {
+  width: 160px;
+  height: 100px;
+  border-radius: 1rem;
+}
+
+.canvas-shape.circle {
+  width: 110px;
+  height: 110px;
+  border-radius: 50%;
+}


### PR DESCRIPTION
## Summary
- add a toolbar and canvas layout for creating simple shapes
- implement drag-and-drop to copy rectangle or circle shapes from the toolbar to the canvas
- enable repositioning of placed shapes with pointer dragging and add supporting styles

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68ccbdb2c2908324aae64dddca5d4a33